### PR TITLE
W-23730329: Update FIPS library versions for Mule 4.7

### DIFF
--- a/modules/ROOT/pages/fips-140-2-compliance-support.adoc
+++ b/modules/ROOT/pages/fips-140-2-compliance-support.adoc
@@ -68,7 +68,7 @@ The following shows how to install and configure Bouncy Castle security provider
 . Download the provider files from https://www.bouncycastle.org/download/bouncy-castle-java-fips/[the BouncyCastle web page].
 +
 ----
-Provider:bc-fips-1.0.2.4  TLS: bctls-fips-1.0.17.jar  PKIX: bcpkix-fips-1.0.7.jar
+Provider:bc-fips-1.0.2.7  TLS: bctls-fips-1.0.24.jar  PKIX: bcpkix-fips-1.0.12.jar
 ----
 +
 . Copy the 3 files downloaded to `/lib/boot` (needed for Mule runtime) and `/mule-agent-plugin/lib` (needed for Mule agent) folders in Mule runtime.


### PR DESCRIPTION
## Summary

Updates the Bouncy Castle FIPS library versions in the FIPS 140-2 compliance instructions:

- `bc-fips` to `1.0.2.7`
- `bctls-fips` to `1.0.24`
- `bcpkix-fips` to `1.0.12`

Refs: W-23730329

## Validation

- `git diff --check`
- Verified each documented provider entry contains the requested versions.