### PR TITLE
W-23730329: Update FIPS library versions for Mule 4.10

### DIFF
--- a/modules/ROOT/pages/fips-140-2-compliance-support.adoc
+++ b/modules/ROOT/pages/fips-140-2-compliance-support.adoc
@@ -47,7 +47,7 @@ These instructions show how to install and configure Bouncy Castle security prov
 . Install the required JAR file into the `$JAVA_HOME/lib/ext` folder.
 +
 ----
-Provider:bc-fips-1.0.2.4  TLS: bctls-fips-1.0.19.jar  PKIX: bcpkix-fips-1.0.7.jar
+Provider:bc-fips-1.0.2.7  TLS: bctls-fips-1.0.24.jar  PKIX: bcpkix-fips-1.0.12.jar
 ----
 +
 . Register the security provider in the security properties file in the `$JAVA_HOME/lib/security/java.security` folder so that only the Bouncy Castle providers are set:
@@ -65,7 +65,7 @@ These instructions show how to install and configure Bouncy Castle security prov
 . Download the provider files from https://www.bouncycastle.org/download/bouncy-castle-java-fips/[the BouncyCastle web page].
 +
 ----
-Provider:bc-fips-1.0.2.4  TLS: bctls-fips-1.0.19.jar  PKIX: bcpkix-fips-1.0.7.jar
+Provider:bc-fips-1.0.2.7  TLS: bctls-fips-1.0.24.jar  PKIX: bcpkix-fips-1.0.12.jar
 ----
 +
 . Register the security provider in the security properties file in the `$JAVA_HOME/conf/security/java.security` folder so that only the Bouncy Castle providers are set.


### PR DESCRIPTION
## Summary

Updates the Bouncy Castle FIPS library versions in the FIPS 140-2 compliance instructions:

- `bc-fips` to `1.0.2.7`
- `bctls-fips` to `1.0.24`
- `bcpkix-fips` to `1.0.12`

Refs: W-23730329

## Validation

- `git diff --check`
- Verified each documented provider entry contains the requested versions.