### PR TITLE
@W-23800673 Document troubleshooting plugin on-demand operations and CLI flags

### DIFF
--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -126,6 +126,8 @@ The Diagnostic Information Analysis File (DIAF) organizes all diagnostic data co
 * <<diaf-title>>
 * <<diaf-basic-info>>
 * <<diaf-system-info>>
+* <<diaf-health-signals>>
+* <<diaf-memory-detail>>
 * <<diaf-network-info>>
 * <<diaf-jvm-agents>>
 * <<diaf-statistics>>
@@ -358,6 +360,95 @@ This section reports host physical memory, not the JVM heap.
 
 | `transfer.time.ms`
 | Total time spent on transfers, in milliseconds.
+|===
+
+[[diaf-health-signals]]
+=== Health Signals
+
+[NOTE]
+====
+Available in Mule runtime 4.12.3 and later.
+====
+
+This section evaluates a small set of fast host- and JVM-level health signals and reports only the ones that fired. The inputs come from JMX and the host operating system, plus a check for a JVM crash log; no log-file contents are read. On a healthy host, this section shows `None`.
+
+Each fired signal is listed on its own line with a short description and, where available, the measured values. The possible signals are:
+
+[cols="1,3", options="header"]
+|===
+| Signal | Meaning
+
+| `Low Available Memory`
+| Available physical memory is below 10% of total memory.
+
+| `No Swap`
+| The host is running without swap memory, on a low-memory host where that is a risk.
+
+| `Low storage`
+| A mounted file system has less than 10% usable space. Reported per affected mount.
+
+| `High CPU Steal`
+| CPU steal time is high, which can indicate low CPU credits on the host (Linux only).
+
+| `High CPU IOWait`
+| CPU I/O wait time is high, which can indicate I/O problems or excessive disk usage (Linux only).
+
+| `JVM was restarted`
+| The JVM process is much younger than the host, suggesting it may have been restarted unexpectedly.
+
+| `JVM crash log present`
+| A JVM fatal-error log (`hs_err_pid<PID>.log`) is present in the runtime logs directory or the JVM error-file location, indicating a previous JVM crash.
+|===
+
+[[diaf-memory-detail]]
+=== Memory Detail
+
+[NOTE]
+====
+Available in Mule runtime 4.12.3 and later.
+====
+
+This section shows the JVM memory-pool breakdown and garbage-collector statistics of the running Mule runtime, read in-process from JMX. It has four blocks: aggregate `Heap` usage, aggregate `Non-Heap` usage, one entry per memory pool under `Memory Pools`, and one entry per collector under `Garbage Collectors`.
+
+The `Heap`, `Non-Heap`, and each `Memory Pools` entry report the following usage fields:
+
+[cols="1,3", options="header"]
+|===
+| Field | Description
+
+| `init`
+| Initial amount of memory the JVM requested for the pool. Shown as `n/a` when the JVM does not define it.
+
+| `used`
+| Amount of memory currently in use.
+
+| `committed`
+| Amount of memory guaranteed to be available to the JVM.
+
+| `max`
+| Maximum amount of memory that can be used. Shown as `n/a` for an unbounded pool.
+
+| `used/committed`
+| Ratio of used to committed memory, as a percentage. Omitted when committed memory isn't positive.
+
+| `used/max`
+| Ratio of used to maximum memory, as a percentage. Omitted when maximum memory isn't defined.
+|===
+
+Each `Memory Pools` entry also reports its `type` (`HEAP` or `NON_HEAP`). Each `Garbage Collectors` entry reports:
+
+[cols="1,3", options="header"]
+|===
+| Field | Description
+
+| `count`
+| Number of collections the collector has performed. Shown as `n/a` when the collector doesn't support the counter.
+
+| `time.ms`
+| Accumulated collection time, in milliseconds. Shown as `n/a` when the collector doesn't support it.
+
+| `pools`
+| Names of the memory pools the collector manages, separated by `|`.
 |===
 
 [[diaf-network-info]]

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -1281,7 +1281,7 @@ The report always shows the following sections, each in this order. Under each s
 | MUnit artifacts found among the deployed applications. MUnit is a test-scope dependency and shouldn't be packaged for deployment. Each detection lists the artifact coordinates followed by this diagnosis.
 
 | `Connector versions:`
-| The connector versions found in the deployed applications, listed for reference. This section reports the deployed versions only; it makes no outbound call and doesn't check whether a newer release is available.
+| The connector versions found in the deployed applications, listed for reference.
 |===
 
 == Considerations

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -438,7 +438,7 @@ Each `Memory Pools` entry also reports its `type` (`HEAP` or `NON_HEAP`). Each `
 | Number of collections the collector has performed. Shown as `n/a` when the collector doesn't support the counter.
 
 | `time.ms`
-| Accumulated collection time, in milliseconds. Shown as `n/a` when the collector doesn't support it.
+| Accumulated collection time, in milliseconds. Shown as `n/a` when the collector doesn't support the field.
 
 | `pools`
 | Names of the memory pools the collector manages, separated by `|`.

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -98,7 +98,7 @@ The `help` output above lists every option and its default. The following behavi
 [NOTE]
 ====
 * `--output <path>`: when `<path>` is an existing directory or ends with a trailing slash (`/`), the tool writes the individual output files into that directory. Any other `<path>` is treated as the archive to create, with the format taken from the extension (for example, `.zip` or `.tar.gz`).
-* `--stdout`: streams the archive to standard output. It is effectively mutually exclusive with `--output`, and isn't supported on Windows.
+* `--stdout`: streams the archive to standard output instead of writing a file, so you can't combine it with `--output`. It isn't supported on Windows.
 * `--debug`: the JVM listens for a remote debugger on port `5005` and suspends until one attaches, so use it only to troubleshoot the tool itself.
 ====
 
@@ -381,7 +381,7 @@ Each fired signal is listed on its own line with a short description and, where 
 | Available physical memory is below 10% of total memory.
 
 | `No Swap`
-| The host is running without swap memory, on a low-memory host where that is a risk.
+| The host has no swap memory configured, which is a risk on a low-memory host.
 
 | `Low storage`
 | A mounted file system has less than 10% usable space. Reported per affected mount.
@@ -416,7 +416,7 @@ The `Heap`, `Non-Heap`, and each `Memory Pools` entry report the following usage
 | Field | Description
 
 | `init`
-| Initial amount of memory the JVM requested for the pool. Shown as `n/a` when the JVM does not define it.
+| Initial amount of memory the JVM requested for the pool. Shown as `n/a` when the JVM doesn't define it.
 
 | `used`
 | Amount of memory currently in use.
@@ -1262,7 +1262,7 @@ Available in Mule runtime 4.12.3 and later. This operation runs on demand only. 
 
 This operation scans the runtime logs and the deployed applications for a set of well-known problem signatures and reports the ones it detects. Use it to surface recurring issues, such as out-of-memory conditions or abnormal terminations, that might otherwise require manual log inspection.
 
-The report always shows the following sections, each in this order. Under each section, the operation lists one line per detected signal, showing the signal, the number of occurrences, and, where available, a short diagnosis. A section with no detections shows `None`. When a source can't be read, the operation shows a marker such as `(source not available: no readable Mule log files found)` instead of a count.
+The report shows these sections, in this order. Under each section, the operation lists one line per detected signal, showing the signal, the number of occurrences, and, where available, a short diagnosis. A section with no detections shows `None`. When a source can't be read, the operation shows a marker such as `(source not available: no readable Mule log files found)` instead of a count.
 
 [cols="1,3", options="header"]
 |===

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -93,29 +93,23 @@ Output:
 
 === Command-Line Options
 
-The `help` output above lists every option and its default. The following behavior isn't spelled out in that summary:
+The previous `help` output lists every option and its default. These behaviors aren't spelled out in that summary:
 
-[NOTE]
-====
 * `--output <path>`: when `<path>` is an existing directory or ends with a trailing slash (`/`), the tool writes the individual output files into that directory. Any other `<path>` is treated as the archive to create, with the format taken from the extension (for example, `.zip` or `.tar.gz`).
 * `--stdout`: streams the archive to standard output instead of writing a file, so you can't combine it with `--output`. It isn't supported on Windows.
 * `--debug`: the JVM listens for a remote debugger on port `5005` and suspends until one attaches, so use it only to troubleshoot the tool itself.
-====
 
 ==== Watch Mode
 
-Watch mode (`--watch`) keeps the tool running and generates a diagnostic dump automatically whenever a `--trigger` condition is met, which is useful for capturing state at the moment an intermittent problem occurs. The `help` output lists the watch options and trigger forms; the following behavior isn't covered there:
+Watch mode (`--watch`) keeps the tool running and generates a diagnostic dump automatically whenever a `--trigger` condition is met, which is useful for capturing state at the moment an intermittent problem occurs. The `help` output lists the watch options and trigger forms. These behaviors aren't covered there:
 
-[NOTE]
-====
-* Watch mode runs in the foreground and blocks the terminal until it reaches `--occurrences` successful dumps or you stop it with kbd:[Ctrl+C].
-* It wraps the default full diagnostic dump, so you can't combine it with a single named operation. Combining it with `--extended` is supported.
+* Watch mode runs in the foreground and blocks the terminal until it reaches `--occurrences` successful dumps, or you stop it with `kbd:[Ctrl+C]`.
+* It wraps the default full diagnostic dump, so you can't combine it with a single named operation. You can combine it with `--extended`.
 * A trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
-====
 
 [NOTE]
 ====
-Watch mode and the `--logsmaxage` / `--logsmaxtotalsize` options are available in Mule runtime 4.12.3 and later.
+Watch mode and the `--logsmaxage` and `--logsmaxtotalsize` options are available in Mule runtime 4.12.3 and later.
 ====
 
 == Understanding Diagnostic Information Analysis File (DIAF)
@@ -369,9 +363,9 @@ This section reports host physical memory, not the JVM heap.
 Available in Mule runtime 4.12.3 and later.
 ====
 
-This section evaluates a small set of fast host- and JVM-level health signals and reports only the ones that fired. The inputs come from JMX and the host operating system, plus a check for a JVM crash log; no log-file contents are read. On a healthy host, this section shows `None`.
+This section evaluates a small set of fast host- and JVM-level health signals and reports only the ones that fired. The inputs come from JMX and the host operating system, plus a check for a JVM crash log. No log-file contents are read. On a healthy host, the section shows `None`.
 
-Each fired signal is listed on its own line with a short description and, where available, the measured values. The possible signals are:
+Each fired signal is listed on its own line with a short description and, where available, the measured values. These are the possible signals:
 
 [cols="1,3", options="header"]
 |===
@@ -393,7 +387,7 @@ Each fired signal is listed on its own line with a short description and, where 
 | CPU I/O wait time is high, which can indicate I/O problems or excessive disk usage (Linux only).
 
 | `JVM was restarted`
-| The JVM process is much younger than the host, suggesting it may have been restarted unexpectedly.
+| The JVM process is much younger than the host, which can indicate an unexpected restart.
 
 | `JVM crash log present`
 | A JVM fatal-error log (`hs_err_pid<PID>.log`) is present in the runtime logs directory or the JVM error-file location, indicating a previous JVM crash.
@@ -409,7 +403,7 @@ Available in Mule runtime 4.12.3 and later.
 
 This section shows the JVM memory-pool breakdown and garbage-collector statistics of the running Mule runtime, read in-process from JMX. It has four blocks: aggregate `Heap` usage, aggregate `Non-Heap` usage, one entry per memory pool under `Memory Pools`, and one entry per collector under `Garbage Collectors`.
 
-The `Heap`, `Non-Heap`, and each `Memory Pools` entry report the following usage fields:
+The `Heap`, `Non-Heap`, and each `Memory Pools` entry report these usage fields:
 
 [cols="1,3", options="header"]
 |===
@@ -448,6 +442,7 @@ Each `Memory Pools` entry also reports its `type` (`HEAP` or `NON_HEAP`). Each `
 
 | `pools`
 | Names of the memory pools the collector manages, separated by `|`.
+
 |===
 
 [[diaf-network-info]]
@@ -1257,10 +1252,12 @@ The report first shows the handshake outcome as `handshake: success` or `handsha
 
 [NOTE]
 ====
-Available in Mule runtime 4.12.3 and later. This operation runs on demand only. Because it scans the full set of rotated log files, which is disk-intensive, it isn't included in the default diagnostic dump. Run it explicitly by name with `./diag knownIssues`.
+Available in Mule runtime 4.12.3 and later.
+
+This operation runs on demand only. Because it scans the full set of rotated log files, which is disk-intensive, it isn't included in the default diagnostic dump. Run it explicitly by name with `./diag knownIssues`.
 ====
 
-This operation scans the runtime logs and the deployed applications for a set of well-known problem signatures and reports the ones it detects. Use it to surface recurring issues, such as out-of-memory conditions or abnormal terminations, that might otherwise require manual log inspection.
+This operation scans the runtime logs and the deployed applications for a set of well-known problem signatures and reports the ones it detects. Use it to surface recurring issues, such as out-of-memory conditions or abnormal terminations, that otherwise require manual log inspection.
 
 The report shows these sections, in this order. Under each section, the operation lists one line per detected signal, showing the signal, the number of occurrences, and, where available, a short diagnosis. A section with no detections shows `None`. When a source can't be read, the operation shows a marker such as `(source not available: no readable Mule log files found)` instead of a count.
 

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -93,7 +93,7 @@ Output:
 
 === Command-Line Options
 
-The previous `help` output lists every option and its default. These behaviors aren't spelled out in that summary:
+The previous output lists every option and its default. These behaviors aren't mentioned in that summary:
 
 * `--output <path>`: when `<path>` is an existing directory or ends with a trailing slash (`/`), the tool writes the individual output files into that directory. Any other `<path>` is treated as the archive to create, with the format taken from the extension (for example, `.zip` or `.tar.gz`).
 * `--stdout`: streams the archive to standard output instead of writing a file, so you can't combine it with `--output`. It isn't supported on Windows.

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -104,7 +104,7 @@ The previous `help` output lists every option and its default. These behaviors a
 Watch mode (`--watch`) keeps the tool running and generates a diagnostic dump automatically whenever a `--trigger` condition is met, which is useful for capturing state at the moment an intermittent problem occurs. The `help` output lists the watch options and trigger forms. These behaviors aren't covered there:
 
 * Watch mode runs in the foreground and blocks the terminal until it reaches the number of successful dumps specified by `--occurrences`, or you stop it with `kbd:[Ctrl+C]`.
-* It wraps the default full diagnostic dump, so you can't combine it with a single named operation. You can combine it with `--extended`.
+* Watch mode wraps the default full diagnostic dump, so you can't combine it with a single named operation. You can combine it with `--extended`.
 * A trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
 
 [NOTE]

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -110,7 +110,6 @@ Watch mode (`--watch`) keeps the tool running and generates a diagnostic dump au
 ====
 * Watch mode runs in the foreground and blocks the terminal until it reaches `--occurrences` successful dumps or you stop it with kbd:[Ctrl+C].
 * It wraps the default full diagnostic dump, so you can't combine it with a single named operation. Combining it with `--extended` is supported.
-* A `conns>N` / `conns<N` trigger, which fires on the server connection count, is also available. It requires the `connectionCount` operation, available in Mule runtime 4.12.4 and later.
 * A trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
 ====
 

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -103,7 +103,7 @@ The previous `help` output lists every option and its default. These behaviors a
 
 Watch mode (`--watch`) keeps the tool running and generates a diagnostic dump automatically whenever a `--trigger` condition is met, which is useful for capturing state at the moment an intermittent problem occurs. The `help` output lists the watch options and trigger forms. These behaviors aren't covered there:
 
-* Watch mode runs in the foreground and blocks the terminal until it reaches `--occurrences` successful dumps, or you stop it with `kbd:[Ctrl+C]`.
+* Watch mode runs in the foreground and blocks the terminal until it reaches the number of successful dumps specified by `--occurrences`, or you stop it with `kbd:[Ctrl+C]`.
 * It wraps the default full diagnostic dump, so you can't combine it with a single named operation. You can combine it with `--extended`.
 * A trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
 

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -23,7 +23,7 @@ The plugin works out-of-the-box in the Standalone, CloudHub, and CloudHub 2.0 de
 
 Run this command from your Mule runtime installation at `$MULE_HOME/tools/diag` to generate the DIAF and a thread dump. By default, the tool saves the files unzipped in the `logs` directory of the distribution.
 
-Use the `./diag --extended` command to generate a heap dump. Use `./diag --output some/dir/name/` to create the directories if they don't exist and save unzipped files there. Use `./diag --output some/dir/name` (without a trailing `/`) to create a ZIP file at that path containing all output files.
+Use the `./diag --extended` command to generate a heap dump. Use `./diag --output some/dir/name/` to create the directories if they don't exist and save unzipped files there. Use `./diag --output some/dir/name` (without a trailing `/`) to create an archive at that path containing all output files. The tool uses ZIP format when the `zip` command is available and falls back to TAR.GZ otherwise.
 
 On Windows, run `diag.bat`. The `--stdout` option isn't supported.
 
@@ -31,7 +31,7 @@ The plugin's help output lists the available commands and options.
 
 [source,bash]
 ----
-➜  mule-enterprise-standalone-4.6.23 ./tools/diag help
+➜  mule-enterprise-standalone-4.12.3 ./tools/diag help
 Mule Troubleshooting Tool
 =========================
 
@@ -45,25 +45,151 @@ Commands:
 Global Options:
   --stdout                Output the diagnostic dump to standard output
   --output <path>         Specify custom output directory or file path
-  --extended              Enable extended mode (includes heap dump)
+  --extended              Enable extended mode (heap dump + file artifacts: conf, logs, server-plugins, apps, domains, policies)
+  --logsmaxage <days>     Maximum age in days for logs collected with --extended (default 7, 0 disables)
+  --logsmaxtotalsize <mb> Maximum total size in MB for logs collected with --extended (default 100, 0 disables)
   --debug                 Enable debug mode with remote debugging on port 5005
+
+Watch Mode (generate dumps automatically when a condition is met):
+  --watch                 Poll runtime metrics and fire a diagnostic dump when a --trigger condition is met
+  --trigger <condition>   Trigger condition (repeatable; a dump fires when any one matches). Forms:
+                            cpu>N / cpu<N       CPU load percentage above/below N
+                            heap>N / heap<N     heap usage percentage above/below N
+                            thread>N / thread<N live thread count above/below N
+                            time=N              every N seconds
+                            cron=<expression>   on a Quartz cron schedule (e.g. cron=0 0/5 * * * ?)
+                            script=<path>       when <path> exits with a non-zero status
+  --occurrences <n>       Number of dumps to fire before stopping (default 1; 0 or negative = unlimited)
+  --checkperiod <seconds> How often to check the triggers, in seconds (default 30; a lower time=N trigger takes precedence)
 
 Examples:
   ./diag                          # Generate diagnostic dump to logs directory
   ./diag --stdout                 # Output diagnostic dump to stdout
-  ./diag --extended               # Include heap dump in diagnostic
-  ./diag --output /tmp/mule.zip   # Save to specific file
+  ./diag --extended               # Include heap dump and file artifacts in diagnostic
+  ./diag --output /tmp/mule       # Save to specific file (see Archive Format below)
   ./diag --output /tmp/           # Save to specific directory
   ./diag <operation-name>         # Execute specific operation
+  ./diag --watch --trigger heap>90              # Dump once when heap usage exceeds 90%
+  ./diag --watch --trigger cpu>80 --trigger time=300 --occurrences 0 --checkperiod 10
+                                  # Dump every time CPU exceeds 80% or every 300s, checking every 10s, forever
+  ./diag --watch --trigger 'cron=0 0/5 * * * ?' --extended
+                                  # Extended dump every 5 minutes on a cron schedule
 
 Output:
-  By default, the tool creates a ZIP file containing:
+  The tool creates an archive file containing:
   - mule_dump_<timestamp>.diaf    # Diagnostic information
   - thread_dump_<timestamp>.txt   # Thread dump
   - heap_dump_<timestamp>.hprof   # Heap dump (if --extended is used)
+  - tls_support/                  # TLS introspection results (if available)
+  If --extended is used, the following are also included:
+  - conf/, logs/, server-plugins/, apps/, domains/, policies/
+                                  # logs/ capped at 100MB / 7 days by default
+                                  # configurable via --logsmaxtotalsize / --logsmaxage
 
-  The ZIP file is saved to the 'logs' directory by default.
+  Archive Format:
+  - Uses ZIP format when 'zip' command is available
+  - Falls back to TAR.GZ format when only 'tar' is available
 ----
+
+=== Command-Line Options
+
+The following options control what the tool collects and where it writes the output.
+
+[cols="1,1,3", options="header"]
+|===
+| Option | Default | Description
+
+| `--output <path>`
+| `$MULE_BASE/logs/`
+| Sets where the output is written. If `<path>` is an existing directory or ends with a trailing slash (`/`), the tool writes the individual output files into that directory. Otherwise, the tool writes a single archive at that path, choosing the format from the extension (for example, `.zip` or `.tar.gz`).
+
+| `--stdout`
+| Off
+| Streams the diagnostic archive to standard output instead of writing files to disk. Use it to pipe the output to another process or to a remote host. This option is effectively mutually exclusive with `--output`, and isn't supported on Windows.
+
+| `--extended`
+| Off
+| Enables extended mode. In addition to the DIAF and thread dump, the tool captures a heap dump and collects the runtime's configuration, logs, server plugins, applications, domains, and policies.
+
+| `--logsmaxage <days>`
+| `7`
+| When collecting logs in extended mode, includes only log files modified within the last `<days>` days. Set to `0` to disable the age filter. This option applies only together with `--extended`.
+
+| `--logsmaxtotalsize <mb>`
+| `100`
+| When collecting logs in extended mode, caps the total size of collected log files at `<mb>` megabytes. Set to `0` to disable the size cap. This option applies only together with `--extended`.
+
+| `--debug`
+| Off
+| Starts the tool with remote JVM debugging enabled, listening on port `5005` and suspending until a debugger attaches. Use it only to troubleshoot the tool itself.
+|===
+
+[NOTE]
+====
+The `--logsmaxage` and `--logsmaxtotalsize` options are available in Mule runtime 4.12.3 and later.
+====
+
+==== Watch Mode
+
+[NOTE]
+====
+Available in Mule runtime 4.12.3 and later.
+====
+
+Use watch mode to keep the tool running and generate a diagnostic dump automatically whenever a condition you define is met. This is useful for capturing state at the moment an intermittent problem occurs, without watching the instance manually.
+
+Watch mode runs in the foreground and blocks the terminal until it reaches the configured number of occurrences or you stop it with kbd:[Ctrl+C]. It wraps the default full diagnostic dump; you can't combine it with a single named operation. Combining `--watch` with `--extended` is supported and honors the extended-mode log options.
+
+[cols="1,1,3", options="header"]
+|===
+| Option | Default | Description
+
+| `--watch`
+| Off
+| Enables watch mode. Requires at least one `--trigger`.
+
+| `--trigger <condition>`
+| None
+| Defines a condition that fires a dump. Repeat the option to add more conditions; they combine with OR, so the first matching condition on a given check fires one dump. See the trigger conditions below.
+
+| `--occurrences <n>`
+| `1`
+| Stops watch mode after `<n>` successful dumps. Set to `0` or a negative value for unlimited occurrences. Only successful dumps count toward the limit.
+
+| `--checkperiod <seconds>`
+| `30`
+| Sets how often, in seconds, the tool evaluates the trigger conditions. Must be greater than `0`.
+|===
+
+The `--trigger` option accepts these conditions:
+
+[cols="1,3", options="header"]
+|===
+| Condition | Description
+
+| `cpu>N` / `cpu<N`
+| Fires when system CPU load rises above or falls below `N` percent.
+
+| `heap>N` / `heap<N`
+| Fires when heap usage rises above or falls below `N` percent.
+
+| `thread>N` / `thread<N`
+| Fires when the live thread count rises above or falls below `N`.
+
+| `conns>N` / `conns<N`
+| Fires when the server connection count rises above or falls below `N`. Requires the `connectionCount` operation, available in Mule runtime 4.12.4 and later.
+
+| `time=N`
+| Fires every `N` seconds. When any `time=N` trigger is present, the effective check interval is the smaller of `--checkperiod` and the smallest `time=N` value.
+
+| `cron=<expression>`
+| Fires on a Quartz cron schedule.
+
+| `script=<path>`
+| Fires when the script at `<path>` exits with a non-zero status.
+|===
+
+A metric-based trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
 
 == Understanding Diagnostic Information Analysis File (DIAF)
 
@@ -84,6 +210,7 @@ The Diagnostic Information Analysis File (DIAF) organizes all diagnostic data co
 * <<diaf-cluster-info>>
 * <<diaf-agent-info>>
 * <<diaf-platform-connectivity>>
+* <<diaf-known-issues>>
 
 [[diaf-title]]
 === Title
@@ -1105,6 +1232,38 @@ The report first shows the handshake outcome as `handshake: success` or `handsha
 
 | `issuer`
 | Issuer distinguished name of the certificate.
+|===
+
+[[diaf-known-issues]]
+=== Known Issues
+
+[NOTE]
+====
+Available in Mule runtime 4.12.3 and later. This operation runs on demand only. Because it scans the full set of rotated log files, which is disk-intensive, it isn't included in the default diagnostic dump. Run it explicitly by name with `./diag knownIssues`.
+====
+
+This operation scans the runtime logs and the deployed applications for a set of well-known problem signatures and reports the ones it detects. Use it to surface recurring issues, such as out-of-memory conditions or abnormal terminations, that might otherwise require manual log inspection.
+
+The report always shows the following sections, each in this order. Under each section, the operation lists one line per detected signal, showing the signal, the number of occurrences, and, where available, a short diagnosis. A section with no detections shows `None`. When a source can't be read, the operation shows a marker such as `(source not available: no readable Mule log files found)` instead of a count.
+
+[cols="1,3", options="header"]
+|===
+| Section | Description
+
+| `Memory:`
+| Out-of-memory conditions detected in the Mule logs, including Java heap, PermGen, and Metaspace exhaustion.
+
+| `Linux OOM-killer:`
+| Events where the Linux kernel out-of-memory killer terminated a process, detected in the kernel logs.
+
+| `Abnormal termination:`
+| Signs of an abnormal JVM termination, such as a `SIGKILL`, an unexpected JVM exit, or a CloudHub restart trigger, detected in the runtime and monitor logs.
+
+| `MUnit at runtime:`
+| MUnit artifacts found among the deployed applications. MUnit is a test-scope dependency and shouldn't be packaged for deployment. Each detection lists the artifact coordinates followed by this diagnosis.
+
+| `Connector versions:`
+| The connector versions found in the deployed applications, listed for reference. This section reports the deployed versions only; it makes no outbound call and doesn't check whether a newer release is available.
 |===
 
 == Considerations

--- a/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
+++ b/modules/ROOT/pages/mule-troubleshooting-plugin.adoc
@@ -93,103 +93,31 @@ Output:
 
 === Command-Line Options
 
-The following options control what the tool collects and where it writes the output.
-
-[cols="1,1,3", options="header"]
-|===
-| Option | Default | Description
-
-| `--output <path>`
-| `$MULE_BASE/logs/`
-| Sets where the output is written. If `<path>` is an existing directory or ends with a trailing slash (`/`), the tool writes the individual output files into that directory. Otherwise, the tool writes a single archive at that path, choosing the format from the extension (for example, `.zip` or `.tar.gz`).
-
-| `--stdout`
-| Off
-| Streams the diagnostic archive to standard output instead of writing files to disk. Use it to pipe the output to another process or to a remote host. This option is effectively mutually exclusive with `--output`, and isn't supported on Windows.
-
-| `--extended`
-| Off
-| Enables extended mode. In addition to the DIAF and thread dump, the tool captures a heap dump and collects the runtime's configuration, logs, server plugins, applications, domains, and policies.
-
-| `--logsmaxage <days>`
-| `7`
-| When collecting logs in extended mode, includes only log files modified within the last `<days>` days. Set to `0` to disable the age filter. This option applies only together with `--extended`.
-
-| `--logsmaxtotalsize <mb>`
-| `100`
-| When collecting logs in extended mode, caps the total size of collected log files at `<mb>` megabytes. Set to `0` to disable the size cap. This option applies only together with `--extended`.
-
-| `--debug`
-| Off
-| Starts the tool with remote JVM debugging enabled, listening on port `5005` and suspending until a debugger attaches. Use it only to troubleshoot the tool itself.
-|===
+The `help` output above lists every option and its default. The following behavior isn't spelled out in that summary:
 
 [NOTE]
 ====
-The `--logsmaxage` and `--logsmaxtotalsize` options are available in Mule runtime 4.12.3 and later.
+* `--output <path>`: when `<path>` is an existing directory or ends with a trailing slash (`/`), the tool writes the individual output files into that directory. Any other `<path>` is treated as the archive to create, with the format taken from the extension (for example, `.zip` or `.tar.gz`).
+* `--stdout`: streams the archive to standard output. It is effectively mutually exclusive with `--output`, and isn't supported on Windows.
+* `--debug`: the JVM listens for a remote debugger on port `5005` and suspends until one attaches, so use it only to troubleshoot the tool itself.
 ====
 
 ==== Watch Mode
 
+Watch mode (`--watch`) keeps the tool running and generates a diagnostic dump automatically whenever a `--trigger` condition is met, which is useful for capturing state at the moment an intermittent problem occurs. The `help` output lists the watch options and trigger forms; the following behavior isn't covered there:
+
 [NOTE]
 ====
-Available in Mule runtime 4.12.3 and later.
+* Watch mode runs in the foreground and blocks the terminal until it reaches `--occurrences` successful dumps or you stop it with kbd:[Ctrl+C].
+* It wraps the default full diagnostic dump, so you can't combine it with a single named operation. Combining it with `--extended` is supported.
+* A `conns>N` / `conns<N` trigger, which fires on the server connection count, is also available. It requires the `connectionCount` operation, available in Mule runtime 4.12.4 and later.
+* A trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
 ====
 
-Use watch mode to keep the tool running and generate a diagnostic dump automatically whenever a condition you define is met. This is useful for capturing state at the moment an intermittent problem occurs, without watching the instance manually.
-
-Watch mode runs in the foreground and blocks the terminal until it reaches the configured number of occurrences or you stop it with kbd:[Ctrl+C]. It wraps the default full diagnostic dump; you can't combine it with a single named operation. Combining `--watch` with `--extended` is supported and honors the extended-mode log options.
-
-[cols="1,1,3", options="header"]
-|===
-| Option | Default | Description
-
-| `--watch`
-| Off
-| Enables watch mode. Requires at least one `--trigger`.
-
-| `--trigger <condition>`
-| None
-| Defines a condition that fires a dump. Repeat the option to add more conditions; they combine with OR, so the first matching condition on a given check fires one dump. See the trigger conditions below.
-
-| `--occurrences <n>`
-| `1`
-| Stops watch mode after `<n>` successful dumps. Set to `0` or a negative value for unlimited occurrences. Only successful dumps count toward the limit.
-
-| `--checkperiod <seconds>`
-| `30`
-| Sets how often, in seconds, the tool evaluates the trigger conditions. Must be greater than `0`.
-|===
-
-The `--trigger` option accepts these conditions:
-
-[cols="1,3", options="header"]
-|===
-| Condition | Description
-
-| `cpu>N` / `cpu<N`
-| Fires when system CPU load rises above or falls below `N` percent.
-
-| `heap>N` / `heap<N`
-| Fires when heap usage rises above or falls below `N` percent.
-
-| `thread>N` / `thread<N`
-| Fires when the live thread count rises above or falls below `N`.
-
-| `conns>N` / `conns<N`
-| Fires when the server connection count rises above or falls below `N`. Requires the `connectionCount` operation, available in Mule runtime 4.12.4 and later.
-
-| `time=N`
-| Fires every `N` seconds. When any `time=N` trigger is present, the effective check interval is the smaller of `--checkperiod` and the smallest `time=N` value.
-
-| `cron=<expression>`
-| Fires on a Quartz cron schedule.
-
-| `script=<path>`
-| Fires when the script at `<path>` exits with a non-zero status.
-|===
-
-A metric-based trigger whose metric can't be sampled on the current host never fires, so it doesn't produce false dumps.
+[NOTE]
+====
+Watch mode and the `--logsmaxage` / `--logsmaxtotalsize` options are available in Mule runtime 4.12.3 and later.
+====
 
 == Understanding Diagnostic Information Analysis File (DIAF)
 


### PR DESCRIPTION
## Summary

Documents the Mule Troubleshooting plugin's new DIAF sections and CLI options in `mule-troubleshooting-plugin.adoc`, targeting the upcoming 4.12.3 release. Per the usual workflow the PR is opened against `v4.12` with the specific corresponding version noted for each item, so the docs team knows what to add.

### What's documented

- **New DIAF dump sections** — **Health Signals** (fast host/JVM signals, reports only the ones that fired) and **Memory Detail** (JVM memory-pool breakdown + garbage-collector statistics). These render between System Info and Network Info.
- **Known Issues** DIAF section (on-demand, run with `./diag knownIssues`) — the five fixed report sections: Memory, Linux OOM-killer, Abnormal termination, MUnit at runtime, Connector versions.
- **Refreshed `help` output block** — now matches the current tool output, including the new options and Watch Mode.
- **Command-Line Options** — short notes covering only the behavior the `help` summary doesn't spell out (`--output` path semantics, `--stdout` Windows/exclusivity, `--debug` suspend).
- **Watch Mode** — notes on the behavior beyond the `help` listing (foreground/blocking, wraps the full dump, version availability).

The CLI options and trigger forms are listed once, in the `help` example block; the prose only adds what `help` doesn't convey, to avoid duplication.

### Version notes (please confirm)

Everything documented here targets **Mule runtime 4.12.3**:

| Item | Noted version |
|---|---|
| Health Signals section | 4.12.3 |
| Memory Detail section | 4.12.3 |
| `knownIssues` operation | 4.12.3 |
| `--logsmaxage` / `--logsmaxtotalsize` | 4.12.3 |
| Watch Mode (`--watch` and options) | 4.12.3 |

The `conns` trigger is intentionally omitted: it depends on the `connectionCount` operation, which lands in 4.12.4 rather than the 4.12.3 release this doc targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)