### PR TITLE
W-23949994-Clarify CH2 Maven properties preserve vs secureProperties-kt

### DIFF
--- a/modules/ROOT/pages/_partials/mmp-concept.adoc
+++ b/modules/ROOT/pages/_partials/mmp-concept.adoc
@@ -143,6 +143,9 @@ For example:
   <http.port>8081</http.port>
 </secureProperties>
 ----
+If you redeploy the application and neither the `secureProperties` nor the `properties` element is configured in the deployment POM file, CloudHub 2.0 preserves the existing secure properties configured in your CloudHub 2.0 environment.
+If either element is present, CloudHub 2.0 deploys the application using only the properties and secure properties defined in the POM. It doesn't merge them with values configured in Runtime Manager. Any existing secure properties that aren't included in the deployment configuration are removed.
+To keep existing values, omit both elements, or send the full set of properties and secure properties on every redeploy.
 | No
 // end::securePropertiesCH2ParameterDescription[]
 

--- a/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
+++ b/modules/ROOT/pages/_partials/mmp-deploy-to-cloudhub-2.adoc
@@ -206,8 +206,9 @@ For example:
   <http.port>8081</http.port>
 </properties>
 ----
-If you redeploy the application and the `properties` element isn't configured in the deployment POM file, the existing properties configured in your CloudHub 2.0 environment are preserved.
-If the `properties` element is present in the deployment POM file, the application is deployed using only the properties defined in that element, overriding any properties configured in Runtime Manager. Any existing properties that aren't included in the deployment configuration are removed.
+If you redeploy the application and neither the `properties` nor the `secureProperties` element is configured in the deployment POM file, CloudHub 2.0 preserves the existing properties configured in your CloudHub 2.0 environment.
+If either element is present, CloudHub 2.0 deploys the application using only the properties and secure properties defined in the POM. It doesn't merge them with values configured in Runtime Manager. Any existing properties that aren't included in the deployment configuration are removed.
+To keep existing values, omit both elements, or send the full set of properties and secure properties on every redeploy.
 | No
 | `propertiesFile` | Top-level element +
 Specifies a file that contains properties for the Mule application being deployed. Use this parameter as an alternative to defining properties inline with `<properties>`. The file must use the Java properties format, with one `key=value` pair per line. | No


### PR DESCRIPTION
## Summary
- Clarify that CloudHub 2.0 Maven redeploys preserve Runtime Manager properties only when both `<properties>` and `<secureProperties>` are omitted from the POM.
- Document that if either element is present, both property types are replaced (not merged), so you must omit both or resend the full set.
- Scope is the CloudHub 2.0 Maven deploy reference only; CloudHub 1.0 and Runtime Fabric copy is unchanged.

GUS: [W-23949994](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iQxwwYAC/view)

## Request vs. change
| Ticket request | Status |
|---|---|
| Qualify the `properties` preserve note | Updated in `mmp-deploy-to-cloudhub-2.adoc` |
| Document `secureProperties` omit/replace behavior | Updated in `securePropertiesCH2ParameterDescription` |
| Combined rule: either element overwrites both types | Added to both parameter cells |
| CloudHub 1.0 / Runtime Fabric | Already separate; not duplicated |

## Sources
- GUS W-23949994 — the doc request
- GUS W-23908927 — investigation (Coast Capital Savings; Closed - Doc/Usability)
- Slack #ms-support-swarm-sds — https://salesforce.enterprise.slack.com/archives/C02RV8J2MST/p1787062376.380079
- Related REST/CLI tickets (not changed here): W-19771578, W-19742275, W-18517988

## Test plan
- [ ] Confirm the CloudHub 2.0 Maven deploy reference table renders both `properties` and `secureProperties` cells without AsciiDoc breakage
- [ ] Confirm CloudHub 1.0 and Runtime Fabric Maven pages still use their own parameter tags and are unchanged
- [ ] Confirm `propertiesFile` is still documented separately and was not given this preserve/replace rule